### PR TITLE
Activate optional chaining

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,8 @@
   },
   "babel": {
     "plugins": [
-      "svelte-loadable/babel"
+      "svelte-loadable/babel",
+      "@babel/plugin-proposal-optional-chaining"
     ]
   },
   "eslintConfig": {


### PR DESCRIPTION
This will only work in JS files, not within `script` elements in `svelte` files (sniff).